### PR TITLE
Convert build system to use cmake and fix for Mac OS X build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
-*.o
 dsd
+*.[ao]
+*.so*
+*.dylib
+build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,21 @@
+project(dsd)
+cmake_minimum_required(VERSION 2.6)
+ 
+FILE(GLOB SRCS *.c)
+ 
+INCLUDE_DIRECTORIES("${PROJECT_SOURCE_DIR}" "${CMAKE_INSTALL_PREFIX}/include")
+LINK_DIRECTORIES("${CMAKE_INSTALL_PREFIX}/lib")
+ 
+ADD_EXECUTABLE(dsd ${SRCS})
+TARGET_LINK_LIBRARIES(dsd mbe)
+ 
+install(TARGETS dsd DESTINATION bin)
+
+# uninstall target
+configure_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/cmake_uninstall.cmake.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
+    IMMEDIATE @ONLY)
+
+add_custom_target(uninstall
+    COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)

--- a/Makefile
+++ b/Makefile
@@ -14,9 +14,9 @@
 # PERFORMANCE OF THIS SOFTWARE.
 
 CC = gcc
-CFLAGS = -O2 -Wall
-INCLUDES = -I. -I/usr/local/include -I/usr/include
-LIBS = -L/usr/local/lib -lm -lmbe 
+CFLAGS = -O2 -Wall -g
+INCLUDES = -I. -I/usr/local/include -I/usr/include -I../mbelib-master
+LIBS = -L/usr/local/lib -L../mbelib-master -lm -lmbe 
 INSTALL=install
 AR=ar
 RANLIB=ranlib

--- a/cmake_uninstall.cmake.in
+++ b/cmake_uninstall.cmake.in
@@ -1,0 +1,23 @@
+if (NOT EXISTS "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt")
+    message(FATAL_ERROR "Cannot find install manifest: \"@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt\"")
+endif(NOT EXISTS "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt")
+
+file(READ "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt" files)
+string(REGEX REPLACE "\n" ";" files "${files}")
+cmake_policy(SET CMP0007 OLD)
+list(REVERSE files)
+foreach (file ${files})
+    message(STATUS "Uninstalling \"$ENV{DESTDIR}${file}\"")
+    if (EXISTS "$ENV{DESTDIR}${file}")
+        execute_process(
+            COMMAND @CMAKE_COMMAND@ -E remove "$ENV{DESTDIR}${file}"
+            OUTPUT_VARIABLE rm_out
+            RESULT_VARIABLE rm_retval
+        )
+        if(NOT ${rm_retval} EQUAL 0)
+            message(FATAL_ERROR "Problem when removing \"$ENV{DESTDIR}${file}\"")
+        endif (NOT ${rm_retval} EQUAL 0)
+    else (EXISTS "$ENV{DESTDIR}${file}")
+        message(STATUS "File \"$ENV{DESTDIR}${file}\" does not exist.")
+    endif (EXISTS "$ENV{DESTDIR}${file}")
+endforeach(file)

--- a/dsd.h
+++ b/dsd.h
@@ -31,7 +31,7 @@
 #ifdef SOLARIS
 #include <sys/audioio.h>
 #endif
-#ifdef BSD
+#if defined(BSD) && !defined(__APPLE__)
 #include <sys/soundcard.h>
 #endif
 #include <math.h>

--- a/dsd_audio.c
+++ b/dsd_audio.c
@@ -237,7 +237,7 @@ openAudioOutDevice (dsd_opts * opts, int speed)
     }
 #endif
 
-#ifdef BSD
+#if defined(BSD) && !defined(__APPLE__)
 
   int fmt;
 
@@ -318,7 +318,7 @@ openAudioInDevice (dsd_opts * opts)
     }
 #endif
 
-#ifdef BSD
+#if defined(BSD) && !defined(__APPLE__)
   int fmt;
 
   if (opts->split == 1)


### PR DESCRIPTION
As above. Please test.

Mac OS X does not have any audio device in /dev, but rather Core Audio needs to be used. What would be the best way to fix this? Should I use something like portaudio for cross platform audio support?

What I'll probably do first is implement libsndfile support for processing recorded .wavs, as this would make reverse-engineering codecs much easier. What do you think?
