### PR TITLE
Reduce undefined behaviour of casting NaN to an integer type

### DIFF
--- a/dsd_audio.c
+++ b/dsd_audio.c
@@ -171,6 +171,10 @@ writeSynthesizedVoice (dsd_opts * opts, dsd_state * state)
         {
           *state->audio_out_temp_buf_p = (float) -32760;
         }
+      else if (isnan(*state->audio_out_temp_buf_p))
+        {
+          *state->audio_out_temp_buf_p = (float) 0;
+        }
       *aout_buf_p = (short) *state->audio_out_temp_buf_p;
       aout_buf_p++;
       state->audio_out_temp_buf_p++;


### PR DESCRIPTION
This fixes noise/popping issues when compiled with Cygwin 32-bit. casting a non-finite number to an integer type is undefined in C.

isnan() is a C99/C++11 function. I'm not sure whether this will break anywhere; apparently Windows has an _isnan() function that does the same thing but I haven't tested this.

Also, is there a possibility the mbelib output produces inf values; isinf() would have to be used to check that.
