### PR TITLE
Potential fix for P25 encryption muting

### DIFF
--- a/dsd.h
+++ b/dsd.h
@@ -166,7 +166,7 @@ typedef struct
   mbe_parms *cur_mp;
   mbe_parms *prev_mp;
   mbe_parms *prev_mp_enhanced;
-  int p25kid;
+  int p25algid;
 } dsd_state;
 
 /*

--- a/dsd_main.c
+++ b/dsd_main.c
@@ -217,7 +217,7 @@ initState (dsd_state * state)
   state->prev_mp = malloc (sizeof (mbe_parms));
   state->prev_mp_enhanced = malloc (sizeof (mbe_parms));
   mbe_initMbeParms (state->cur_mp, state->prev_mp, state->prev_mp_enhanced);
-  state->p25kid = 0;
+  state->p25algid = 0x80;
 }
 
 void

--- a/p25p1_hdu.c
+++ b/p25p1_hdu.c
@@ -258,7 +258,7 @@ processHDU (dsd_opts * opts, dsd_state * state)
 
   skipDibit (opts, state, 160);
 
-  state->p25kid = strtol(kid, NULL, 2);
+  state->p25algid = strtol(algid, NULL, 2);
 
   if (opts->p25enc == 1)
     {

--- a/p25p1_ldu1.c
+++ b/p25p1_ldu1.c
@@ -77,7 +77,7 @@ processLDU1 (dsd_opts * opts, dsd_state * state)
           y++;
           z++;
         }
-      if (state->p25kid == 0)
+      if (state->p25algid == 0x80)
         {
           processMbeFrame (opts, state, imbe_fr, NULL, NULL);
         }

--- a/p25p1_ldu2.c
+++ b/p25p1_ldu2.c
@@ -80,7 +80,7 @@ processLDU2 (dsd_opts * opts, dsd_state * state)
           y++;
           z++;
         }
-      if (state->p25kid == 0)
+      if (state->p25algid == 0x80)
         {
     	  processMbeFrame (opts, state, imbe_fr, NULL, NULL);
         }


### PR DESCRIPTION
This may fix the erroneous muting of unencrypted P25 packets. However, I'm lacking a P25 sample and have no way to test it, so can someone please test it and report on whether it works before this is merged?
