### PR TITLE
Add option -pu to unmute encrypted p25 audio

### DIFF
--- a/README.md
+++ b/README.md
@@ -499,6 +499,7 @@ rate and serial port device if necessary.
 -mc           Use only C4FM modulation optimizations
 -mg           Use only GFSK modulation optimizations
 -mq           Use only QPSK modulation optimizations
+-pu           Unmute Encrypted P25
 -u <num>      Unvoiced speech quality (default=3)
 -xx           Expect non-inverted X2-TDMA signal
 -xr           Expect inverted DMR/MOTOTRBO signal

--- a/dsd.h
+++ b/dsd.h
@@ -100,6 +100,7 @@ typedef struct
   int playfiles;
   int delay;
   int use_cosine_filter;
+  int unmute_encrypted_p25;
 } dsd_opts;
 
 typedef struct

--- a/dsd_main.c
+++ b/dsd_main.c
@@ -129,6 +129,7 @@ initOpts (dsd_opts * opts)
   opts->playfiles = 0;
   opts->delay = 0;
   opts->use_cosine_filter = 1;
+  opts->unmute_encrypted_p25 = 0;
 }
 
 void
@@ -269,6 +270,7 @@ usage ()
   printf ("  -mc           Use only C4FM modulation optimizations\n");
   printf ("  -mg           Use only GFSK modulation optimizations\n");
   printf ("  -mq           Use only QPSK modulation optimizations\n");
+  printf ("  -pu           Unmute Encrypted P25\n");
   printf ("  -u <num>      Unvoiced speech quality (default=3)\n");
   printf ("  -xx           Expect non-inverted X2-TDMA signal\n");
   printf ("  -xr           Expect inverted DMR/MOTOTRBO signal\n");
@@ -375,6 +377,10 @@ main (int argc, char **argv)
           else if (optarg[0] == 't')
             {
               opts.p25tg = 1;
+            }
+          else if (optarg[0] == 'u')
+            {
+            opts.unmute_encrypted_p25 = 1;
             }
           break;
         case 'q':

--- a/p25p1_ldu1.c
+++ b/p25p1_ldu1.c
@@ -77,7 +77,7 @@ processLDU1 (dsd_opts * opts, dsd_state * state)
           y++;
           z++;
         }
-      if (state->p25kid == 0)
+      if (state->p25kid == 0 || opts->unmute_encrypted_p25 == 1)
         {
           processMbeFrame (opts, state, imbe_fr, NULL, NULL);
         }

--- a/p25p1_ldu2.c
+++ b/p25p1_ldu2.c
@@ -80,7 +80,7 @@ processLDU2 (dsd_opts * opts, dsd_state * state)
           y++;
           z++;
         }
-      if (state->p25kid == 0)
+      if (state->p25kid == 0 || opts->unmute_encrypted_p25 == 1)
         {
     	  processMbeFrame (opts, state, imbe_fr, NULL, NULL);
         }


### PR DESCRIPTION
  This option existed in the orginal 1.6.0 commit 20271c6d
