### PR TITLE
Fixes a crash if an irrecoverable error happens

### DIFF
--- a/p25p1_tdulc.c
+++ b/p25p1_tdulc.c
@@ -288,7 +288,8 @@ processTDULC (dsd_opts* opts, dsd_state* state)
 
 
   // Next 10 dibits should be zeros
-  read_zeros(opts, state, analog_signal_array + 6*(6+6)+6*(6+6), 20, &status_count, 0);
+  // If an irrecoverable error happens, you should start a new sequence since the previous dibit was not set
+  read_zeros(opts, state, analog_signal_array + 6*(6+6)+6*(6+6), 20, &status_count, irrecoverable_errors);
 
   // Next we should find an status dibit
   if (status_count != 35) {


### PR DESCRIPTION
If an irrecoverable error happens, you should start a new sequence
since the previous dibit was not set. Ed might have a better way of fixing this, but this seems to work for me. This is in relation to Issue 33
