### PR TITLE
libsndfile can be used to open a UNIX-style pipe

### DIFF
--- a/dsd_audio.c
+++ b/dsd_audio.c
@@ -465,7 +465,22 @@ void
 openAudioInDevice (dsd_opts * opts)
 {
   // get info of device/file
-	if(strncmp(opts->audio_in_dev, "pa:", 2) == 0)
+	if(strncmp(opts->audio_in_dev, "-", 1) == 0)
+	{
+		opts->audio_in_type = 1;
+		opts->audio_in_file_info = calloc(1, sizeof(SF_INFO));
+		opts->audio_in_file_info->samplerate=48000;
+		opts->audio_in_file_info->channels=1;
+		opts->audio_in_file_info->seekable=0;
+		opts->audio_in_file_info->format=SF_FORMAT_RAW|SF_FORMAT_PCM_16|SF_ENDIAN_LITTLE;
+		opts->audio_in_file = sf_open_fd(fileno(stdin), SFM_READ, opts->audio_in_file_info, 0);
+
+		if(opts->audio_in_file == NULL) {
+			printf ("Error, couldn't open stdin with libsndfile: %s\n", sf_strerror(NULL));
+			exit(1);
+		}
+	}
+	else if(strncmp(opts->audio_in_dev, "pa:", 2) == 0)
 	{
 		opts->audio_in_type = 2;
 #ifdef USE_PORTAUDIO


### PR DESCRIPTION
In specific, it can be used to read in data almost directly from Gqrx
Currently, this will not function correctly using -i /dev/stdin on OS X
because stdin is not seekable, and it is not actually a file; also, for
ongoing raw data, there are no hints for libsndfile to identify the
sample.

So, we can use the UNIX-y '-' to do libsndfile-approved fd handle open.

Tested with the dsd-samples wav after converting it to correct sampletype
(stereo) -> sox p25_raw_unencrypted_edf.wav -c 2 ~/gqrx_last_recorded_filename.wav
.. and then pressing 'play' in the Gqrx interface while running:

socat udp-listen:7355 - | dsd -i - -o pa:2

.. in the background. And it decoded it nicely as many times as I played it,
which was 5 or 10.
