### PR TITLE
Fix multiple definition of exitflag when compiling

### DIFF
--- a/include/dsd.h
+++ b/include/dsd.h
@@ -61,7 +61,7 @@
 /*
  * global variables
  */
-int exitflag;
+static int exitflag;
 
 
 typedef struct


### PR DESCRIPTION
When compiling on my system I get the following errors:

```
[ 84%] Linking CXX executable dsd
/usr/bin/ld: CMakeFiles/dsd.dir/src/dmr_voice.c.o:(.bss+0x0): multiple definition of `exitflag'; CMakeFiles/dsd.dir/src/dmr_data.c.o:(.bss+0x0): first defined here
/usr/bin/ld: CMakeFiles/dsd.dir/src/dsd_audio.c.o:(.bss+0x0): multiple definition of `exitflag'; CMakeFiles/dsd.dir/src/dmr_data.c.o:(.bss+0x0): first defined here
/usr/bin/ld: CMakeFiles/dsd.dir/src/dsd_dibit.c.o:(.bss+0x0): multiple definition of `exitflag'; CMakeFiles/dsd.dir/src/dmr_data.c.o:(.bss+0x0): first defined here
/usr/bin/ld: CMakeFiles/dsd.dir/src/dsd_file.c.o:(.bss+0x0): multiple definition of `exitflag'; CMakeFiles/dsd.dir/src/dmr_data.c.o:(.bss+0x0): first defined here
/usr/bin/ld: CMakeFiles/dsd.dir/src/dsd_frame.c.o:(.bss+0x0): multiple definition of `exitflag'; CMakeFiles/dsd.dir/src/dmr_data.c.o:(.bss+0x0): first defined here
/usr/bin/ld: CMakeFiles/dsd.dir/src/dsd_frame_sync.c.o:(.bss+0x0): multiple definition of `exitflag'; CMakeFiles/dsd.dir/src/dmr_data.c.o:(.bss+0x0): first defined here
/usr/bin/ld: CMakeFiles/dsd.dir/src/dsd_main.c.o:(.bss+0x0): multiple definition of `exitflag'; CMakeFiles/dsd.dir/src/dmr_data.c.o:(.bss+0x0): first defined here
/usr/bin/ld: CMakeFiles/dsd.dir/src/dsd_mbe.c.o:(.bss+0x0): multiple definition of `exitflag'; CMakeFiles/dsd.dir/src/dmr_data.c.o:(.bss+0x0): first defined here
/usr/bin/ld: CMakeFiles/dsd.dir/src/dsd_serial.c.o:(.bss+0x0): multiple definition of `exitflag'; CMakeFiles/dsd.dir/src/dmr_data.c.o:(.bss+0x0): first defined here
/usr/bin/ld: CMakeFiles/dsd.dir/src/dsd_symbol.c.o:(.bss+0x0): multiple definition of `exitflag'; CMakeFiles/dsd.dir/src/dmr_data.c.o:(.bss+0x0): first defined here
/usr/bin/ld: CMakeFiles/dsd.dir/src/dsd_upsample.c.o:(.bss+0x0): multiple definition of `exitflag'; CMakeFiles/dsd.dir/src/dmr_data.c.o:(.bss+0x0): first defined here
/usr/bin/ld: CMakeFiles/dsd.dir/src/dstar.c.o:(.bss+0x0): multiple definition of `exitflag'; CMakeFiles/dsd.dir/src/dmr_data.c.o:(.bss+0x0): first defined here
/usr/bin/ld: CMakeFiles/dsd.dir/src/nxdn96.c.o:(.bss+0x0): multiple definition of `exitflag'; CMakeFiles/dsd.dir/src/dmr_data.c.o:(.bss+0x0): first defined here
/usr/bin/ld: CMakeFiles/dsd.dir/src/nxdn_data.c.o:(.bss+0x0): multiple definition of `exitflag'; CMakeFiles/dsd.dir/src/dmr_data.c.o:(.bss+0x0): first defined here
/usr/bin/ld: CMakeFiles/dsd.dir/src/nxdn_voice.c.o:(.bss+0x0): multiple definition of `exitflag'; CMakeFiles/dsd.dir/src/dmr_data.c.o:(.bss+0x0): first defined here
/usr/bin/ld: CMakeFiles/dsd.dir/src/p25_lcw.c.o:(.bss+0x0): multiple definition of `exitflag'; CMakeFiles/dsd.dir/src/dmr_data.c.o:(.bss+0x0): first defined here
/usr/bin/ld: CMakeFiles/dsd.dir/src/p25p1_hdu.c.o:(.bss+0x0): multiple definition of `exitflag'; CMakeFiles/dsd.dir/src/dmr_data.c.o:(.bss+0x0): first defined here
/usr/bin/ld: CMakeFiles/dsd.dir/src/p25p1_heuristics.c.o:(.bss+0x0): multiple definition of `exitflag'; CMakeFiles/dsd.dir/src/dmr_data.c.o:(.bss+0x0): first defined here
/usr/bin/ld: CMakeFiles/dsd.dir/src/p25p1_ldu.c.o:(.bss+0x0): multiple definition of `exitflag'; CMakeFiles/dsd.dir/src/dmr_data.c.o:(.bss+0x0): first defined here
/usr/bin/ld: CMakeFiles/dsd.dir/src/p25p1_ldu1.c.o:(.bss+0x0): multiple definition of `exitflag'; CMakeFiles/dsd.dir/src/dmr_data.c.o:(.bss+0x0): first defined here
/usr/bin/ld: CMakeFiles/dsd.dir/src/p25p1_ldu2.c.o:(.bss+0x0): multiple definition of `exitflag'; CMakeFiles/dsd.dir/src/dmr_data.c.o:(.bss+0x0): first defined here
/usr/bin/ld: CMakeFiles/dsd.dir/src/p25p1_tdu.c.o:(.bss+0x0): multiple definition of `exitflag'; CMakeFiles/dsd.dir/src/dmr_data.c.o:(.bss+0x0): first defined here
/usr/bin/ld: CMakeFiles/dsd.dir/src/p25p1_tdulc.c.o:(.bss+0x0): multiple definition of `exitflag'; CMakeFiles/dsd.dir/src/dmr_data.c.o:(.bss+0x0): first defined here
/usr/bin/ld: CMakeFiles/dsd.dir/src/provoice.c.o:(.bss+0x0): multiple definition of `exitflag'; CMakeFiles/dsd.dir/src/dmr_data.c.o:(.bss+0x0): first defined here
/usr/bin/ld: CMakeFiles/dsd.dir/src/x2tdma_data.c.o:(.bss+0x0): multiple definition of `exitflag'; CMakeFiles/dsd.dir/src/dmr_data.c.o:(.bss+0x0): first defined here
/usr/bin/ld: CMakeFiles/dsd.dir/src/x2tdma_voice.c.o:(.bss+0x0): multiple definition of `exitflag'; CMakeFiles/dsd.dir/src/dmr_data.c.o:(.bss+0x0): first defined here
clang-11: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [CMakeFiles/dsd.dir/build.make:617: dsd] Error 1
make[1]: *** [CMakeFiles/Makefile2:188: CMakeFiles/dsd.dir/all] Error 2
make: *** [Makefile:160: all] Error 2
```

This happens with both clang and gcc. The variable, `exitflag`, is defined in `include/dsd.h` and this file is included by a lot of `.c` files, hence the multiple definitions.

I made this variable `static` so the linker doesn't complain.