### PR TITLE
Fix lack of 'extern' option for exitflag.

### DIFF
--- a/include/dsd.h
+++ b/include/dsd.h
@@ -61,7 +61,7 @@
 /*
  * global variables
  */
-int exitflag;
+extern int exitflag;
 
 
 typedef struct

--- a/src/dsd_main.c
+++ b/src/dsd_main.c
@@ -28,6 +28,7 @@
 #include "p25p1_heuristics.h"
 #include "pa_devs.h"
 
+int exitflag = 0;
 
 int
 comp (const void *a, const void *b)
@@ -466,7 +467,6 @@ main (int argc, char **argv)
   initOpts (&opts);
   initState (&state);
 
-  exitflag = 0;
   signal (SIGINT, sigfun);
 
   while ((c = getopt (argc, argv, "haep:qstv:z:i:o:d:g:nw:B:C:R:f:m:u:x:A:S:M:rl")) != -1)


### PR DESCRIPTION
In a debian system (either using cmake/make) or dpkg-buildpackage,
linking will fail since exitflag is not declared as extern in the
include file. This commit does so and initializes it in dsd_main.c
as a global.