### PR TITLE
Initialize last_dibit variable

### DIFF
--- a/src/dsd_main.c
+++ b/src/dsd_main.c
@@ -236,6 +236,8 @@ initState (dsd_state * state)
   state->debug_header_errors = 0;
   state->debug_header_critical_errors = 0;
 
+  state->last_dibit = 0;
+
 #ifdef TRACE_DSD
   state->debug_sample_index = 0;
   state->debug_label_file = NULL;


### PR DESCRIPTION
A segfault can occur because `last_dibit` is uninitialized and used as an index in a lookup table (in `estimate_symbol`).

This was reported in https://github.com/argilo/gr-dsd/pull/15 and fixed in https://github.com/argilo/gr-dsd/pull/19. Since the fix works well in gr-dsd, I'm contributing the fix upstream.